### PR TITLE
Update Travis config to accomodate repo transfer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ branches:
   only:
   - master
   - "/^v[0-9].*$/"
+  - jfc/repo-transfer
 language: python
 python: '3.6'
 services:
@@ -19,8 +20,8 @@ deploy:
     application: document-search
     deployment_group: staging
     on:
-      repo: datamade/document-search
-      branch: master
+      repo: fpdcc/document-search
+      branch: jfc/repo-transfer
   - provider: codedeploy
     access_key_id: AKIAQJGP4DUASZSYFRWW
     secret_access_key:
@@ -28,5 +29,5 @@ deploy:
     application: document-search
     deployment_group: production
     on:
-      repo: datamade/document-search
+      repo: fpdcc/document-search
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ branches:
   only:
   - master
   - "/^v[0-9].*$/"
-  - jfc/repo-transfer
 language: python
 python: '3.6'
 services:
@@ -21,7 +20,7 @@ deploy:
     deployment_group: staging
     on:
       repo: fpdcc/document-search
-      branch: jfc/repo-transfer
+      branch: master
   - provider: codedeploy
     access_key_id: AKIAQJGP4DUASZSYFRWW
     secret_access_key:


### PR DESCRIPTION
## Overview

Now that this repo lives under the `fpdcc` org, update the Travis CI config to accomodate the new location.

## Testing Instructions

* I updated Travis to run builds and deploys from this branch and successfully saw a deploy and Slack notification, so I think this PR is good.
