### PR TITLE
Make sure to sort nulls last for all fields

### DIFF
--- a/docsearch/templates/docsearch/base_search.html
+++ b/docsearch/templates/docsearch/base_search.html
@@ -44,7 +44,7 @@
           </div>
         </div>
       </form>
-      {% if selected_facet_fields %}
+      {% if selected_facet_fields or sort or query %}
           <a href="{{ request.path }}" class="btn btn-outline-secondary">
             <i class="fa fa-fw fa-times"></i> Start over
           </a>

--- a/docsearch/views/easements.py
+++ b/docsearch/views/easements.py
@@ -29,4 +29,4 @@ class EasementSearch(base_views.BaseSearchView):
     model = models.Easement
     template_name = 'docsearch/easements/search.html'
     facet_fields = ['easement_number']
-    sort_fields = ['easement_number', 'description_exact'] 
+    sort_fields = ['easement_number_exact', 'description_exact']

--- a/docsearch/views/flatdrawings.py
+++ b/docsearch/views/flatdrawings.py
@@ -35,7 +35,7 @@ class FlatDrawingSearch(base_views.BaseSearchView):
     facet_fields = ['area', 'section', 'map_number', 'location', 'job_number',
                     'number_of_sheets', 'date', 'cross_ref_area',
                     'cross_ref_section', 'cross_ref_map_number']
-    sort_fields = ['area', 'section_exact', 'map_number', 'location_exact', 'description_exact',
-                   'job_number_exact', 'number_of_sheets', 'date_exact',
-                   'cross_ref_area', 'cross_ref_section',
+    sort_fields = ['area', 'section_exact', 'map_number_exact', 'location_exact',
+                   'description_exact', 'job_number_exact', 'number_of_sheets_exact',
+                   'date_exact', 'cross_ref_area', 'cross_ref_section',
                    'cross_ref_map_number_exact']

--- a/docsearch/views/indexcards.py
+++ b/docsearch/views/indexcards.py
@@ -30,4 +30,4 @@ class IndexCardSearch(base_views.BaseSearchView):
     model = models.IndexCard
     template_name = 'docsearch/indexcards/search.html'
     facet_fields = ['monument_number', 'township', 'section', 'corner']
-    sort_fields = ['monument_number', 'township', 'section', 'corner_exact']
+    sort_fields = ['monument_number_exact', 'township', 'section_exact', 'corner_exact']

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -56,4 +56,8 @@ class LicenseSearch(base_views.BaseSearchView):
         'township_arr': 'township',
         'range_arr': 'range'
     }
-    sort_fields = facet_fields + ['description_exact']
+    sort_fields = [
+        'license_number_exact', 'township_arr', 'range_arr', 'section_arr',
+        'type_exact', 'status_exact', 'end_date_exact', 'agreement_type_exact',
+        'description_exact'
+    ]

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -57,7 +57,7 @@ class LicenseSearch(base_views.BaseSearchView):
         'range_arr': 'range'
     }
     sort_fields = [
-        'license_number_exact', 'township_arr', 'range_arr', 'section_arr',
-        'type_exact', 'status_exact', 'end_date_exact', 'agreement_type_exact',
-        'description_exact'
+        'license_number_exact', 'description_exact', 'township_arr', 'range_arr',
+        'section_arr', 'type_exact', 'status_exact', 'end_date_exact',
+        'agreement_type_exact'
     ]

--- a/docsearch/views/projectfiles.py
+++ b/docsearch/views/projectfiles.py
@@ -32,5 +32,5 @@ class ProjectFileSearch(base_views.BaseSearchView):
     template_name = 'docsearch/projectfiles/search.html'
     facet_fields = ['area', 'section', 'job_number', 'job_name',
                     'cabinet_number', 'drawer_number']
-    sort_fields = ['area', 'section', 'description_exact', 'job_number',
-                   'job_name_exact', 'cabinet_number', 'drawer_number']
+    sort_fields = ['area', 'section_exact', 'description_exact', 'job_number_exact',
+                   'job_name_exact', 'cabinet_number_exact', 'drawer_number_exact']

--- a/docsearch/views/surplusparcels.py
+++ b/docsearch/views/surplusparcels.py
@@ -30,4 +30,4 @@ class SurplusParcelSearch(base_views.BaseSearchView):
     template_name = 'docsearch/surplusparcels/search.html'
     facet_fields = ['surplus_parcel']
     search_fields = facet_fields
-    sort_fields = facet_fields
+    sort_fields = facet_fields + ['description_exact']

--- a/docsearch/views/surveys.py
+++ b/docsearch/views/surveys.py
@@ -36,6 +36,6 @@ class SurveySearch(base_views.BaseSearchView):
                     'job_number', 'number_of_sheets', 'date']
     facet_field_name_overrides = {'township_arr': 'township', 'section_arr': 'section',
                                   'range_arr': 'range'}
-    sort_fields = ['township_arr', 'range_arr', 'section_arr', 'map_number',
+    sort_fields = ['township_arr', 'range_arr', 'section_arr', 'map_number_exact',
                    'location_exact', 'description_exact', 'job_number_exact',
-                   'number_of_sheets', 'date']
+                   'number_of_sheets_exact', 'date_exact']


### PR DESCRIPTION
## Overview

Currently, the behavior of the app is inconsistent in whether it displays null values first or last when sorting on specific fields. Update all search views to make sure that nulls are always sorted last. 
 
Connects #37.

## Testing Instructions

It's annoyingly rote, but the best way to test this PR is to visit the search view for each document type, test every sort option with the value `ascending`, and make sure for each option that the first value shown in the list isn't null. Note that there are two columns that will show nulls anyway: `Survey:Number of sheets` and `Survey:Date`, both of which have no non-null values in the current data.
