### PR TITLE
Fix activity search function

### DIFF
--- a/docsearch/templates/docsearch/activity.html
+++ b/docsearch/templates/docsearch/activity.html
@@ -49,7 +49,7 @@
         null,
         null,
         null,
-        {orderable: false}, // Disable ordering on detail view link
+        {searchable: false, orderable: false}, // Disable searching/ordering on detail view link
       ]
     });
   });

--- a/docsearch/views/__init__.py
+++ b/docsearch/views/__init__.py
@@ -35,8 +35,8 @@ class Activity(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
 class ActivityData(BaseDatatableView, UserPassesTestMixin):
     model = models.ActionLog
-    columns = ['timestamp', 'user', 'action', 'content_type', 'object_id', 'content_object']
-    order_columns = ['timestamp', 'user', 'action', 'content_type', 'object_id', '']
+    columns = ['timestamp', 'user.username', 'action', 'content_type.model', 'object_id', 'content_object']
+    order_columns = ['timestamp', 'user.username', 'action', 'content_type.model', 'object_id', '']
     max_display_length = 100
 
     def render_column(self, row, column):

--- a/docsearch/views/__init__.py
+++ b/docsearch/views/__init__.py
@@ -41,7 +41,7 @@ class ActivityData(BaseDatatableView, UserPassesTestMixin):
 
     def render_column(self, row, column):
         if column == 'timestamp':
-            return row.timestamp.strftime("%B %-m, %Y, %-I:%-M %p")
+            return row.timestamp.strftime("%B %-m, %Y, %-I:%M %p")
         elif column == 'content_object':
             return '<a href="{}">{}</a>'.format(
                 row.content_object.get_absolute_url(),

--- a/docsearch/views/base.py
+++ b/docsearch/views/base.py
@@ -193,7 +193,7 @@ class BaseDocumentData(BaseDatatableView, DocumentPermissionRequiredMixin):
 
     def render_column(self, row, column):
         if column == 'timestamp':
-            return row.timestamp.strftime("%B %-m, %Y, %-I:%-M %p")
+            return row.timestamp.strftime("%B %-m, %Y, %-I:%M %p")
         else:
             return super().render_column(row, column)
 

--- a/docsearch/views/base.py
+++ b/docsearch/views/base.py
@@ -187,8 +187,8 @@ class BaseDocumentData(BaseDatatableView, DocumentPermissionRequiredMixin):
     model = models.ActionLog
     document_model = None  # Children must set this attribute
     permission_action = 'view'
-    columns = ['timestamp', 'user', 'action']
-    order_columns = ['timestamp', 'user', 'action']
+    columns = ['timestamp', 'user.username', 'action']
+    order_columns = ['timestamp', 'user.username', 'action']
     max_display_length = 100
 
     def render_column(self, row, column):


### PR DESCRIPTION
## Overview

Update the DataTables configuration on search views to allow searching on username and content type fields.

Handles #52.

## Testing Instructions

* Make sure you have some edits that will show up in the activity search views
    * If you don't, just edit any document and save it without adjusting any fields
* Visit the global activity search view at http://localhost:8000/activity/ and confirm you can run searches
* Navigate to the detail view for a document that has changed (you can do this by following the link in the global activity search view), scroll down to the activity table at the bottom of the page, and confirm that you can run searches
