### PR TITLE
Add About page

### DIFF
--- a/docsearch/templates/docsearch/about.html
+++ b/docsearch/templates/docsearch/about.html
@@ -1,0 +1,37 @@
+{% extends "docsearch/base_content.html" %}
+
+{% block title %}About{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-sm-12">
+    <h1 class="mb-3">
+      About
+    </h1>
+    <p>
+      This Document Search App is how the Planning and Development department
+      of the Forest Preserves of Cook County catalogs many of its project documents.
+      Below is a brief description of each category.
+    </p>
+    <ul>
+      <li><strong>Books</strong> – Surveyor field notebooks.</li>
+      <li><strong>Control Monument Maps</strong> – Documentation on placement of monument markers.</li>
+      <li><strong>Surplus Parcels</strong> – Documentation on surplus parcels.</li>
+      <li><strong>Deep Tunnels</strong> – MWRD Deep Tunnel project documentation.</li>
+      <li><strong>Dossiers</strong> – Title Policies, Abstracts, Appraisals, other misc. documents.</li>
+      <li><strong>Easements</strong> – Documentation on easements.</li>
+      <li><strong>Flat Drawings</strong> – Drawings of projects managed by the Planning and Development Dept. These would include; buildings, trails, and parking lots.</li>
+      <li><strong>Index Cards</strong> – Survey monument records.</li>
+      <li><strong>Licenses</strong> – Licenses issued by the District.</li>
+      <li><strong>Project Files</strong> – Planning and Development project files.</li>
+      <li><strong>Rights of Way</strong> – Documentation on right of ways within District property.</li>
+      <li><strong>Surveys</strong> – Surveys of property acquired by the District.</li>
+      <li><strong>Titles</strong> – Titles, Deeds, Judgment Orders of property acquired by the District.</li>
+    </ul>
+    <p>
+      Additional documentation on using the app is available
+      <a href="https://docs.google.com/document/d/19kgEViMIBVwCvDhUYfGJZ2490oe1ZcwGOE6b6i9FzM4/edit?usp=sharing">here</a>.
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/docsearch/templates/docsearch/base.html
+++ b/docsearch/templates/docsearch/base.html
@@ -87,6 +87,9 @@
               </li>
             {% endif %}
             <li class="nav-item">
+              <a class="nav-link" href="{% url 'about' %}">About</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link" href="{% url 'logout' %}">Sign out</a>
             </li>
           {% endif %}
@@ -121,6 +124,9 @@
                   <a class="nav-link" href="{% url 'activity' %}">Activity</a>
                 </li>
               {% endif %}
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'about' %}">About</a>
+              </li>
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'logout' %}">Sign out</a>
               </li>

--- a/docsearch/urls/__init__.py
+++ b/docsearch/urls/__init__.py
@@ -51,5 +51,6 @@ urlpatterns = [
     path('logout/', auth.views.LogoutView.as_view(template_name='docsearch/logout.html'), name='logout'),
     path('activity/', views.Activity.as_view(), name='activity'),
     path('activity/data/', views.ActivityData.as_view(), name='activity-data'),
+    path('about/', views.About.as_view(), name='about'),
     path('pong/', views.pong),
 ]

--- a/docsearch/views/__init__.py
+++ b/docsearch/views/__init__.py
@@ -23,6 +23,10 @@ class Home(LoginRequiredMixin, TemplateView):
     template_name = 'docsearch/index.html'
 
 
+class About(LoginRequiredMixin, TemplateView):
+    template_name = 'docsearch/about.html'
+
+
 class Activity(LoginRequiredMixin, UserPassesTestMixin, ListView):
     model = models.ActionLog
     context_object_name = 'actions'


### PR DESCRIPTION
## Overview

Add a simple About page to the app, documenting the different types of documents available in the system.

Connects #39. 

## Testing Instructions

* Visit http://localhost:8000 and confirm you see the `About` link in the header and footer
* Follow both links and confirm they take you to http://localhost:8000/about
* Check the text on http://localhost:8000/about and confirm it looks good
