### PR TITLE
Improve search UX

### DIFF
--- a/docsearch/static/css/custom.css
+++ b/docsearch/static/css/custom.css
@@ -80,6 +80,10 @@ body {
   }
 }
 
+a.results-link:visited {
+  color: #551A8B;
+}
+
 /* sorting */
 
 .sort-container {

--- a/docsearch/templates/docsearch/base_detail.html
+++ b/docsearch/templates/docsearch/base_detail.html
@@ -15,6 +15,13 @@
 {% block content %}
 <div class="row">
   <div class="col-12">
+    {% if '/search/' in request.META.HTTP_REFERER %}
+      <div class="mb-3">
+        <a href="{{ request.META.HTTP_REFERER }}#result-{{ object.id }}">
+          <i class="fa fa-fw fa-arrow-left"></i>Back to search results
+        </a>
+      </div>
+    {% endif %}
     <h1>
       {{ view.model|verbose_name|title }}
       <small class="float-right">

--- a/docsearch/templates/docsearch/base_search.html
+++ b/docsearch/templates/docsearch/base_search.html
@@ -221,7 +221,7 @@
           </thead>
           <tbody>
             {% for result in object_list %}
-              <tr>
+              <tr id="result-{{ result.object.id }}">
                 {% block tr %}{% endblock %}
               </tr>
             {% empty %}

--- a/docsearch/templates/docsearch/books/search.html
+++ b/docsearch/templates/docsearch/books/search.html
@@ -15,7 +15,7 @@
   <td>{{ result.object.township|display_range|default_if_none:"" }}</td>
   <td>{{ result.object.range|display_range|default_if_none:"" }}</td>
   <td>{{ result.object.section|display_range|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 
 {% block empty_colspan %}4{% endblock %}

--- a/docsearch/templates/docsearch/controlmonumentmaps/search.html
+++ b/docsearch/templates/docsearch/controlmonumentmaps/search.html
@@ -15,6 +15,6 @@
   <td>{{ result.object.range|default_if_none:"" }}</td>
   <td>{{ result.object.section|display_array|default_if_none:"" }}</td>
   <td>{{ result.object.part_of_section|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link"href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}5{% endblock %}

--- a/docsearch/templates/docsearch/deeptunnels/search.html
+++ b/docsearch/templates/docsearch/deeptunnels/search.html
@@ -8,6 +8,6 @@
 {% endblock %}
 {% block tr %}
   <td>{{ result.object.description|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}2{% endblock %}

--- a/docsearch/templates/docsearch/dossiers/search.html
+++ b/docsearch/templates/docsearch/dossiers/search.html
@@ -10,6 +10,6 @@
 {% block tr %}
   <td>{{ result.object.file_number|default_if_none:"" }}</td>
   <td>{{ result.object.document_number|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}3{% endblock %}

--- a/docsearch/templates/docsearch/easements/search.html
+++ b/docsearch/templates/docsearch/easements/search.html
@@ -10,6 +10,6 @@
 {% block tr %}
   <td>{{ result.object.easement_number|default_if_none:"" }}</td>
   <td>{{ result.object.description|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}3{% endblock %}

--- a/docsearch/templates/docsearch/flatdrawings/search.html
+++ b/docsearch/templates/docsearch/flatdrawings/search.html
@@ -30,6 +30,6 @@
   <td>{{ result.object.cross_ref_area|default_if_none:"" }}</td>
   <td>{{ result.object.cross_ref_section|default_if_none:"" }}</td>
   <td>{{ result.object.cross_ref_map_number|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}13{% endblock %}

--- a/docsearch/templates/docsearch/indexcards/search.html
+++ b/docsearch/templates/docsearch/indexcards/search.html
@@ -14,6 +14,6 @@
   <td>{{ result.object.township|default_if_none:"" }}</td>
   <td>{{ result.object.section|default_if_none:"" }}</td>
   <td>{{ result.object.corner|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}5{% endblock %}

--- a/docsearch/templates/docsearch/licenses/search.html
+++ b/docsearch/templates/docsearch/licenses/search.html
@@ -60,6 +60,6 @@
   <td>{{ result.object.status|default_if_none:"" }}</td>
   <td>{{ result.object.end_date|default_if_none:"" }}</td>
   <td>{{ result.object.agreement_type|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}11{% endblock %}

--- a/docsearch/templates/docsearch/projectfiles/search.html
+++ b/docsearch/templates/docsearch/projectfiles/search.html
@@ -20,6 +20,6 @@
   <td>{{ result.object.job_name|default_if_none:"" }}</td>
   <td>{{ result.object.cabinet_number|default_if_none:"" }}</td>
   <td>{{ result.object.drawer_number|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}8{% endblock %}

--- a/docsearch/templates/docsearch/rightsofway/search.html
+++ b/docsearch/templates/docsearch/rightsofway/search.html
@@ -8,6 +8,6 @@
 {% endblock %}
 {% block tr %}
   <td>{{ result.object.folder_tab|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}5{% endblock %}

--- a/docsearch/templates/docsearch/surplusparcels/search.html
+++ b/docsearch/templates/docsearch/surplusparcels/search.html
@@ -10,6 +10,6 @@
 {% block tr %}
   <td>{{ result.object.surplus_parcel|default_if_none:"" }}</td>
   <td>{{ result.object.description|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}3{% endblock %}

--- a/docsearch/templates/docsearch/surveys/search.html
+++ b/docsearch/templates/docsearch/surveys/search.html
@@ -25,6 +25,6 @@
   <td>{{ result.object.job_number|default_if_none:"" }}</td>
   <td>{{ result.object.number_of_sheets|default_if_none:"" }}</td>
   <td>{{ result.object.date|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}12{% endblock %}

--- a/docsearch/templates/docsearch/titles/search.html
+++ b/docsearch/templates/docsearch/titles/search.html
@@ -8,6 +8,6 @@
 {% endblock %}
 {% block tr %}
   <td>{{ result.object.control_number|default_if_none:"" }}</td>
-  <td><a href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
+  <td><a class="results-link" href="{{ result.object.get_absolute_url }}">View details&nbsp;&raquo;</td>
 {% endblock %}
 {% block empty_colspan %}2{% endblock %}

--- a/docsearch/views/base.py
+++ b/docsearch/views/base.py
@@ -147,7 +147,7 @@ class BaseSearchView(LoginRequiredMixin, DocumentPermissionRequiredMixin, Facete
         sqs = super().get_queryset().models(self.model)
         for facet_field in self.facet_fields:
             # Sort facet options alphabetically, not by hit count
-            sqs = sqs.facet(facet_field, sort='index')
+            sqs = sqs.facet(facet_field, sort='index', limit=1000)
         sort = self._get_sort()
         if sort:
             sqs = sqs.order_by(sort)


### PR DESCRIPTION
## Overview

Three small fixes to improve the search UX:

- Fix a bug related to facet results (#59)
- Style visited search result links (#56)
- Provide a 'back' button to the search page on detail pages (#55)

## Testing Instructions

* Visit http://localhost:8000/flatdrawings/search/?q=palos&selected_facets=area_exact%3A23 and confirm you see `9` as an option in the `Section` facets (#59)
* Choose `View details` for a flat drawing and test #55:
    * Confirm you see a `Back to search results` link at the top of the page
    * Copy the URL to this detail page for later
    * Click the `Back to search results` button
    * Confirm you get taken back to the same search, and directed to the row you clicked on your search 
* Confirm that the `View details` link for the flat drawing you viewed is colored purple instead of blue
* Go back to the homepage at http://localhost:8000, paste the URL to the flat drawing detail page you copied earlier into the address bar, and navigate to the page
    * Confirm that you do not see a `Back to search results` link at the top of the page

