### PR TITLE
Allow read/write users to delete documents

### DIFF
--- a/docsearch/templates/docsearch/base_form.html
+++ b/docsearch/templates/docsearch/base_form.html
@@ -2,6 +2,7 @@
 
 {% load crispy_forms_tags %}
 {% load model_meta %}
+{% load permissions %}
 
 {% block title %}{% if object %}Edit{% else %}Add new{% endif %} {{ view.model|verbose_name|title }}{% endblock %}
 
@@ -19,7 +20,7 @@
         <button class="btn btn-secondary bg-fpdcc-light-green" type="submit">
           {% if object %}Update{% else %}Create{% endif %}
         </button>
-        {% if object and request.user.is_staff %}
+        {% if object and request.user|can_delete:view.model %}
           <a class="btn btn-danger" href="{{ delete_url }}">Delete</a>
         {% endif %}
       </div>

--- a/docsearch/views/base.py
+++ b/docsearch/views/base.py
@@ -96,8 +96,9 @@ class BaseDetailView(LoginRequiredMixin, DocumentPermissionRequiredMixin, Detail
 
 class BaseDeleteView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
     def has_permission(self):
-        # Only Staff users should be able to delete
-        return self.request.user.is_staff
+        # Only Staff or Read/Write users should be able to delete
+        can_read_write = self.request.user.groups.filter(name='Read/Write').exists()
+        return self.request.user.is_staff or can_read_write
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)


### PR DESCRIPTION
## Overview

When viewing a document's edit page, the delete button was only rendering if the user was staff. This allows users with the Read/Write group to also delete.

Closes #91

## Testing Instructions

* Use a superuser to create a new user in the admin
* Add the Read/Write group to that new user
* Log into the app using the read/write user
* Go to a document's detail page an click edit
* Confirm that the delete button displays at the bottom of that page
