### PR TITLE
Add ability to download CAD files from detail pages

### DIFF
--- a/docsearch/templates/docsearch/base_detail.html
+++ b/docsearch/templates/docsearch/base_detail.html
@@ -54,7 +54,11 @@
                   {% if field in view.array_fields %}
                     {{ object|get_attr:field|display_array|default_if_none:"" }}
                   {% else %}
-                    {{ object|get_attr:field|default_if_none:"" }}
+                    {% if field == 'cad_file' and object.cad_file.url %}
+                      <a href="{{ object.cad_file.url }}">{{ object|get_attr:field|default_if_none:"" }}</a> 
+                    {% else %}
+                      {{ object|get_attr:field|default_if_none:"" }}
+                    {% endif %}
                   {% endif %}
                   </td>
               </tr>

--- a/docsearch/templates/docsearch/base_detail.html
+++ b/docsearch/templates/docsearch/base_detail.html
@@ -55,7 +55,7 @@
                     {{ object|get_attr:field|display_array|default_if_none:"" }}
                   {% else %}
                     {% if field == 'cad_file' and object.cad_file.url %}
-                      <a href="{{ object.cad_file.url }}">{{ object|get_attr:field|default_if_none:"" }}</a> 
+                      <a href="{{ object.cad_file.url }}" download>{{ object|get_attr:field|default_if_none:"" }}</a> 
                     {% else %}
                       {{ object|get_attr:field|default_if_none:"" }}
                     {% endif %}


### PR DESCRIPTION
## Overview

CAD files for FlatDrawings were only downloadable from that file's edit page. This change lists the CAD file as a direct download link of the detail page.

Closes #82 

### Demo

![image](https://github.com/fpdcc/document-search/assets/114717958/10ab312a-b0e6-4205-ba81-d430d5c8fda5)

## Testing Instructions

* Navigate to a flatdrawing detail page like http://localhost:8000/flatdrawings/1395/
  * If it doesn't have a CAD file, upload a dummy file in the edit page
* Click the link next to the CAD label and confirm that the file downloads
* Also, confirm that pages without CAD files still load without error

