### PR TITLE
Reorder survey attributes on detail page

### DIFF
--- a/docsearch/views/surveys.py
+++ b/docsearch/views/surveys.py
@@ -5,11 +5,11 @@ from . import base as base_views
 class SurveyDetail(base_views.BaseDetailView):
     model = models.Survey
     template_name = 'docsearch/surveys/detail.html'
-    metadata_fields = ['township', 'range', 'section', 'map_number', 'location',
+    metadata_fields = ['township', 'section', 'range', 'map_number', 'location',
                        'description', 'job_number', 'number_of_sheets',
                        'date', 'cross_ref_area', 'cross_ref_section',
                        'cross_ref_map_number', 'hash', 'source_file']
-    array_fields = ['township', 'range', 'section']
+    array_fields = ['township', 'section', 'range']
 
 
 class SurveyCreate(base_views.BaseCreateView):


### PR DESCRIPTION
## Overview

The survey detail and edit pages had the positioning of the Township and Section fields in different spots. This change makes their order consistent between the two pages.

Closes #70

### Demo

Detail and Edit pages side-by-side
![image](https://github.com/fpdcc/document-search/assets/114717958/e0ea9f3d-d781-4617-b47b-922e1899caa3)

## Testing Instructions

* Navigate to a survey like http://localhost:8000/surveys/1001/
* Confirm that the order of all attributes is the same between the detail and edit page
