### PR TITLE
Render 'back to search url' if coming from search or edit

### DIFF
--- a/docsearch/templates/docsearch/base_detail.html
+++ b/docsearch/templates/docsearch/base_detail.html
@@ -15,9 +15,9 @@
 {% block content %}
 <div class="row">
   <div class="col-12">
-    {% if '/search/' in request.META.HTTP_REFERER %}
+    {% if '/search/' in request.META.HTTP_REFERER or '/update/' in request.META.HTTP_REFERER %}
       <div class="mb-3">
-        <a href="{{ request.META.HTTP_REFERER }}#result-{{ object.id }}">
+        <a href="/{{ object.get_plural_slug }}/search/#result-{{ object.id }}">
           <i class="fa fa-fw fa-arrow-left"></i>Back to search results
         </a>
       </div>


### PR DESCRIPTION
## Overview

The "back to search" link in detail pages was only rendering if the link prior contains '/search/'. This allows it to also render if the link prior contains '/update/' for the edit page

Closes #67

## Testing Instructions

* Search for a document (i.e. books - http://localhost:8000/books/search/ ) and select one of the results
* Confirm that the "back to search" link appears and works
* Back in the document detail page, click Edit, and then Cancel to return to the detail page from the edit page
* Again, confirm that the "back to search" link appears and works
