### PR TITLE
Include license entity, reorder attributes so edit/detail pages match

### DIFF
--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -20,9 +20,9 @@ class LicenseDetail(base_views.BaseDetailView):
     model = models.License
     template_name = 'docsearch/licenses/detail.html'
     metadata_fields = [
-        'license_number', 'description', 'township', 'range', 'section',
-        'type', 'status', 'end_date', 'agreement_type', 'material',
-        'diameter', 'source_file'
+        'license_number', 'description', 'type', 'entity', 'diameter',
+        'material', 'end_date', 'status', 'agreement_type', 'township',
+        'range', 'section', 'source_file',
     ]
     array_fields = ['township', 'range', 'section']
 


### PR DESCRIPTION
## Overview

Entities will now be displayed on license detail pages.

Also since #70 talked about fixing some reordering for attributes for surveys, I went ahead and reordered them here (for licenses) to match what was in the edit page. If we want the original ordering I can absolutely put that back.

Closes #86

## Testing Instructions

* Navigate to a license detail page
* Confirm that entities now shows up as an attribute
