### PR TITLE
Query license by license number

### DIFF
--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -68,17 +68,16 @@ class LicenseSearch(base_views.BaseSearchView):
         try:
             # See if they searched by a license number
             q = self.request.GET.get('q')
+
+            if not q:
+                return qs
+
             id = int(q)
         except ValueError:
             # If not then return the original queryset
             return qs
 
-        qs = qs.filter(license_number=id)
-
-        if qs:
-            return qs
-
-        return qs
+        return qs.filter(license_number=id)
 
 
 class LicenseData(base_views.BaseDocumentData):

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -78,6 +78,8 @@ class LicenseSearch(base_views.BaseSearchView):
         except ValueError:
             # If int casting error then return original queryset
             return qs
+        finally:
+            return qs
 
 
 class LicenseData(base_views.BaseDocumentData):

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -65,16 +65,17 @@ class LicenseSearch(base_views.BaseSearchView):
     def get_queryset(self):
         qs = super().get_queryset()
 
+        q = self.request.GET.get('q')
+
+        if not q:
+            return qs
+
         try:
             # See if they searched by a license number
-            q = self.request.GET.get('q')
-
-            if not q:
-                return qs
-
+            # by casting the search query to an int
             id = int(q)
         except ValueError:
-            # If not then return the original queryset
+            # If int casting error then return original queryset
             return qs
 
         return qs.filter(license_number=id)

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -62,6 +62,19 @@ class LicenseSearch(base_views.BaseSearchView):
         'agreement_type_exact'
     ]
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+
+        id = self.request.GET.get('q')
+
+        if id:
+            qs = qs.filter(license_number=int(id))
+
+            if qs:
+                return qs
+
+        return qs
+
 
 class LicenseData(base_views.BaseDocumentData):
     document_model = models.License

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -74,11 +74,10 @@ class LicenseSearch(base_views.BaseSearchView):
             # See if they searched a license number
             # by casting the search query to an int
             id = int(q)
+            return qs.filter(license_number=id)
         except ValueError:
             # If int casting error then return original queryset
             return qs
-
-        return qs.filter(license_number=id)
 
 
 class LicenseData(base_views.BaseDocumentData):

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -68,6 +68,7 @@ class LicenseSearch(base_views.BaseSearchView):
         q = self.request.GET.get('q')
 
         try:
+            # See if they searched by a license number
             id = int(q)
             qs = qs.filter(license_number=id)
             if qs:
@@ -75,6 +76,8 @@ class LicenseSearch(base_views.BaseSearchView):
         except ValueError:
             pass
 
+        # Return the original queryset if they didn't search
+        # by license number or found no results
         return qs
 
 

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -65,13 +65,16 @@ class LicenseSearch(base_views.BaseSearchView):
     def get_queryset(self):
         qs = super().get_queryset()
 
-        id = self.request.GET.get('q')
 
-        if id:
-            qs = qs.filter(license_number=int(id))
+        q = self.request.GET.get('q')
 
+        try:
+            id = int(q)
+            qs = qs.filter(license_number=id)
             if qs:
                 return qs
+        except ValueError:
+            pass
 
         return qs
 

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -65,19 +65,19 @@ class LicenseSearch(base_views.BaseSearchView):
     def get_queryset(self):
         qs = super().get_queryset()
 
-        q = self.request.GET.get('q')
-
         try:
             # See if they searched by a license number
+            q = self.request.GET.get('q')
             id = int(q)
-            qs = qs.filter(license_number=id)
-            if qs:
-                return qs
         except ValueError:
-            pass
+            # If not then return the original queryset
+            return qs
 
-        # Return the original queryset if they didn't search
-        # by license number or found no results
+        qs = qs.filter(license_number=id)
+
+        if qs:
+            return qs
+
         return qs
 
 

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -65,7 +65,6 @@ class LicenseSearch(base_views.BaseSearchView):
     def get_queryset(self):
         qs = super().get_queryset()
 
-
         q = self.request.GET.get('q')
 
         try:

--- a/docsearch/views/licenses.py
+++ b/docsearch/views/licenses.py
@@ -71,7 +71,7 @@ class LicenseSearch(base_views.BaseSearchView):
             return qs
 
         try:
-            # See if they searched by a license number
+            # See if they searched a license number
             # by casting the search query to an int
             id = int(q)
         except ValueError:


### PR DESCRIPTION
## Overview

- closes #69 

### Demo
<img width="1420" alt="Screenshot 2023-05-19 at 3 20 40 PM" src="https://github.com/fpdcc/document-search/assets/38969506/fe8ff3e7-a7a9-46e1-a0f2-e8e3e0d2dcc2">
<img width="1405" alt="Screenshot 2023-05-19 at 3 45 56 PM" src="https://github.com/fpdcc/document-search/assets/38969506/dbbe4569-d049-496f-a5c6-2daef19e101f">


### Notes
Is there a better way to do this with django-haystack? Or better place to put this logic? I'm doing this in the license search view — all of the django-haystack code in this project is nicely generic for searching across all of the document types.

## Testing Instructions
- search for licenses by number here: http://localhost:8000/licenses/search/
- make sure the faceting + license number combo works
- input some keywords for searching
