### PR TITLE
Handle missing geometry in license form

### DIFF
--- a/docsearch/forms.py
+++ b/docsearch/forms.py
@@ -1,6 +1,6 @@
 import json
 
-from django.forms import ModelForm
+from django.forms import ModelForm, ValidationError
 from django.contrib.gis.forms.fields import GeometryCollectionField
 from haystack.query import SQ
 from haystack.forms import SearchForm
@@ -48,6 +48,9 @@ class LicenseGeometryCollectionField(GeometryCollectionField):
         Convert the value to a GeometryCollection, not natively supported
         by GeoDjango.
         """
+        if not value:
+            return None
+
         val = json.loads(value)
         if val.get('type') != 'GeometryCollection':
             val = {


### PR DESCRIPTION
## Overview

- #85 

## Testing Instructions
- create new license without a geometry: http://localhost:8000/licenses/create/
- confirm the form returns an error about no geometry
