### PR TITLE
Visually clarify which numbers are for which filters

### DIFF
--- a/docsearch/templates/docsearch/base_search.html
+++ b/docsearch/templates/docsearch/base_search.html
@@ -132,17 +132,21 @@
                           {% for value, count in facets.fields|get_key:facet_field %}
                             {% if count > 0 %}
                               {% with facet_field_exact|add:":"|add:value as facet_query %}
-                                <li>
-                                  {% if facet_query in selected_facets %}
-                                    <a href="?{% remove_facet_param parameters facet_field_exact value %}" title="{{ value }}">
-                                      <strong>{{ value }}</strong>&nbsp;<i class="fa fa-fw fa-times"></i>
+                                <li class="border-bottom mb-1">
+                                  <div class="d-inline-block" style="width:80%">
+                                    {% if facet_query in selected_facets %}
+                                      <a href="?{% remove_facet_param parameters facet_field_exact value %}" title="{{ value }}">
+                                        <strong>{{ value }}</strong>&nbsp;<i class="fa fa-fw fa-times"></i>
+                                      </a>
+                                    {% else %}
+                                    <a href="?{% set_facet_param parameters facet_field_exact value %}" title="{{ value }}">
+                                      {{ value }}
                                     </a>
-                                  {% else %}
-                                  <a href="?{% set_facet_param parameters facet_field_exact value %}" title="{{ value }}">
-                                    {{ value }}
-                                  </a>
-                                  {% endif %}
-                                  <span class="badge badge-secondary rounded-pill float-right">{{ count }}</span>
+                                    {% endif %}
+                                  </div>
+                                  <div class="d-inline-block align-top" style="width:15%">
+                                    <span class="badge badge-secondary rounded-pill float-right">{{ count }}</span>
+                                  </div>
                                 </li>
                               {% endwith %}
                             {% endif %}


### PR DESCRIPTION
## Overview

Badges for how many documents were in each filter were misaligned with their filters if the filter name took up too much space. This gives dedicated space to each element and clarifies number/filter pairings

Closes #66

### Demo

Garret's example
![image](https://github.com/fpdcc/document-search/assets/114717958/a0c9dcfb-8679-46f6-b98d-b6dc082e68db)
 <hr>

After
![image](https://github.com/fpdcc/document-search/assets/114717958/3e93bb4a-e704-4da3-8dcf-e08914d5b1ea)

## Testing Instructions

* Navigate to the flatdrawing search page
* Click through the different filter categories, like Location
* Check that
  * only one number badge appears per line
  * it's clear which numbers are for which filters
