### PR TITLE
Make required field asterisk more prominent

### DIFF
--- a/docsearch/static/css/custom.css
+++ b/docsearch/static/css/custom.css
@@ -146,3 +146,8 @@ footer a {
 footer a.dropdown-item {
   color: #212529 !important;
 }
+
+.asteriskField {
+  color:red;
+  font-size: 1.3em;
+}

--- a/docsearch/templates/docsearch/base_form.html
+++ b/docsearch/templates/docsearch/base_form.html
@@ -12,6 +12,7 @@
     <h1 class="mb-3">
       {% if object %}Edit{% else %}Add new{% endif %} {{ view.model|verbose_name|title }}
     </h1>
+    <p><span class="asteriskField">*</span> Indicates a required field</p>
     <form method="POST" enctype="multipart/form-data">
       {% csrf_token %}
       {{ form|crispy }}


### PR DESCRIPTION
## Overview

Help to make required fields more obvious by adding a note at the top of the form mentioning required fields, changing the color of the crispy form's asterisk, and increasing the font size a bit.

Closes #87 

### Demo

![image](https://github.com/fpdcc/document-search/assets/114717958/78e480f1-433e-4c2c-bd03-c353e35ada02)

## Testing Instructions

* Navigate to an "Add New \<Document\>" page (i.e. http://localhost:8000/surveys/create/ )
* Confirm that the required asterisks stand out more
