### PR TITLE
Make reset view button on maps zoom to either the geography or Chicago 

### DIFF
--- a/docsearch/templates/docsearch/licenses/detail.html
+++ b/docsearch/templates/docsearch/licenses/detail.html
@@ -46,6 +46,10 @@
         map.on('viewreset', function() {
           map.fitBounds(geoJsonLayer.getBounds())
         });
+      {% else %}
+        map.on('viewreset', function() {
+          map.setView(L.latLng([41.82, -87.85]), 9)
+        });
       {% endif %}
     }
   </script>

--- a/docsearch/templates/docsearch/licenses/detail.html
+++ b/docsearch/templates/docsearch/licenses/detail.html
@@ -41,6 +41,11 @@
         var geoJsonLayer = L.geoJSON(featureCollection);
         geoJsonLayer.addTo(map);
         map.fitBounds(geoJsonLayer.getBounds());
+
+        // Have the reset view button take the view back to the initial position
+        map.on('viewreset', function() {
+          map.fitBounds(geoJsonLayer.getBounds())
+        });
       {% endif %}
     }
   </script>

--- a/docsearch/templates/docsearch/licenses/form.html
+++ b/docsearch/templates/docsearch/licenses/form.html
@@ -33,6 +33,10 @@
         map.on('viewreset', function() {
           map.fitBounds(geoJsonLayer.getBounds())
         });
+      {% else %}
+        map.on('viewreset', function() {
+          map.setView(L.latLng([41.82, -87.85]), 9)
+        });
       {% endif %}
     });
     $(document).ready(function() {

--- a/docsearch/templates/docsearch/licenses/form.html
+++ b/docsearch/templates/docsearch/licenses/form.html
@@ -23,6 +23,17 @@
         }
       });
       map.addLayer(streets);
+      {% if object.geometry %}
+        var featureCollection = JSON.parse("{{ object.geometry.geojson|escapejs }}");
+        var geoJsonLayer = L.geoJSON(featureCollection);
+        geoJsonLayer.addTo(map);
+        map.fitBounds(geoJsonLayer.getBounds());
+
+        // Have the reset view button take the view back to the initial position
+        map.on('viewreset', function() {
+          map.fitBounds(geoJsonLayer.getBounds())
+        });
+      {% endif %}
     });
     $(document).ready(function() {
       // Make sure the textarea input is a Bootstrap form-control. We need to

--- a/docsearch/templates/docsearch/licenses/search.html
+++ b/docsearch/templates/docsearch/licenses/search.html
@@ -55,6 +55,10 @@
           map.on('viewreset', function() {
             map.fitBounds(geoJsonLayer.getBounds())
           });
+        {% else %}
+          map.on('viewreset', function() {
+            map.setView(L.latLng([41.82, -87.85]), 9)
+          });
         {% endif %}
       }
     </script>

--- a/docsearch/templates/docsearch/licenses/search.html
+++ b/docsearch/templates/docsearch/licenses/search.html
@@ -50,6 +50,11 @@
           var geoJsonLayer = L.geoJSON(featureCollection);
           geoJsonLayer.addTo(map);
           map.fitBounds(geoJsonLayer.getBounds());
+
+          // Have the reset view button take the view back to the initial position
+          map.on('viewreset', function() {
+            map.fitBounds(geoJsonLayer.getBounds())
+          });
         {% endif %}
       }
     </script>


### PR DESCRIPTION
## Overview

Each map's reset view button brought the zoom out to a world view.

This makes the button instead bring you to the initial position, showing the whole geometry for maps that have geometry to show, and to the default position and zoom for Chicago for maps that do not have geometry.

Closes #88 

## Notes

The issue uses Easements as an example of a document with a geography, but it doesn't look like that's the case at the moment.

## Testing Instructions

* Navigate to the search, detail, and edit pages for Licenses
* Zoom, pan, and reset the view on each map
* Confirm that the reset view button:
  * Brings you back to the bounds of the geometry for maps that have them
  * Brings you to a reasonably zoomed view of Chicago for maps without geometry
