### PR TITLE
Patch/doc form validation

### DIFF
--- a/docsearch/forms.py
+++ b/docsearch/forms.py
@@ -2,6 +2,8 @@ import json
 
 from django.forms import ModelForm, ValidationError
 from django.contrib.gis.forms.fields import GeometryCollectionField
+from django.contrib.gis.geos.collections import GeometryCollection
+from django.contrib.gis.gdal.error import GDALException
 from haystack.query import SQ
 from haystack.forms import SearchForm
 
@@ -51,6 +53,10 @@ class LicenseGeometryCollectionField(GeometryCollectionField):
         if not value:
             return None
 
+        # if not isinstance(value, GeometryCollection) or not value.valid or value.empty:
+        #     print("NOT VALID FROM TO PYTHON")
+        #     return None
+        
         val = json.loads(value)
         if val.get('type') != 'GeometryCollection':
             val = {
@@ -68,6 +74,19 @@ class LicenseForm(ModelForm):
         'multiple features for this geometry, define a custom GeoJSON '
         'GeometryCollection and paste it in the box above.'
     ))
+
+    # def clean_geometry(self):
+    #     try:
+    #         data = self.cleaned_data['geometry']
+    #         print('THE GEOMETRY IS:', data)
+    #         if not isinstance(data, GeometryCollection) or not data.valid or data.empty:
+    #             print("NOT VALID")
+    #             raise ValidationError(("Please enter valid GeoJSON"))
+    #     except GDALException:
+    #         print("FROM THE EXCEPT BLOCK")
+    #         raise ValidationError(("Please enter valid GeoJSON"))
+        
+    #     return data
 
     class Meta:
         model = License

--- a/docsearch/forms.py
+++ b/docsearch/forms.py
@@ -52,10 +52,6 @@ class LicenseGeometryCollectionField(GeometryCollectionField):
         """
         if not value:
             return None
-
-        # if not isinstance(value, GeometryCollection) or not value.valid or value.empty:
-        #     print("NOT VALID FROM TO PYTHON")
-        #     return None
         
         val = json.loads(value)
         if val.get('type') != 'GeometryCollection':
@@ -76,14 +72,16 @@ class LicenseForm(ModelForm):
     ))
 
     # def clean_geometry(self):
-    #     try:
-    #         data = self.cleaned_data['geometry']
-    #         print('THE GEOMETRY IS:', data)
-    #         if not isinstance(data, GeometryCollection) or not data.valid or data.empty:
-    #             print("NOT VALID")
-    #             raise ValidationError(("Please enter valid GeoJSON"))
-    #     except GDALException:
-    #         print("FROM THE EXCEPT BLOCK")
+    #     data = self.cleaned_data['geometry']
+    #     # print('THE GEOMETRY IS:', data)
+    #     # print('Valid:', data.valid)
+    #     # print('Empty:', data.empty)
+    #     # print('Coords:', data.num_coords)
+    #     # print('Geom:', data.num_geom)
+    #     # print(data.geojson)
+    #     # print(dir(data))
+    #     if not data.valid or data.empty:
+    #         print("NOT VALID")
     #         raise ValidationError(("Please enter valid GeoJSON"))
         
     #     return data

--- a/docsearch/models.py
+++ b/docsearch/models.py
@@ -7,6 +7,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres import fields as pg_fields
 from django.contrib.postgres import forms as pg_forms
 from django.contrib.gis.db import models as gis_models
+from django.core.validators import FileExtensionValidator
+
+from .validators import validate_positive_int
 
 
 class InclusiveIntegerRangeFormField(pg_forms.IntegerRangeField):
@@ -170,7 +173,7 @@ class Book(BaseDocumentModel):
         null=True,
         blank=True,
         help_text=RANGE_FIELD_HELP_TEXT)
-    source_file = models.FileField(upload_to='BOOKS')
+    source_file = models.FileField(upload_to='BOOKS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class ControlMonumentMap(BaseDocumentModel):
@@ -181,30 +184,33 @@ class ControlMonumentMap(BaseDocumentModel):
         help_text=ARRAY_FIELD_HELP_TEXT
     )
     part_of_section = models.CharField(max_length=255, null=True, blank=True)
-    source_file = models.FileField(upload_to='CONTROL_MONUMENT_MAPS')
+    source_file = models.FileField(upload_to='CONTROL_MONUMENT_MAPS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class SurplusParcel(BaseDocumentModel):
     surplus_parcel = models.CharField(max_length=255, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
-    source_file = models.FileField(upload_to='DEEP_PARCEL_SURPLUS')
+    source_file = models.FileField(upload_to='DEEP_PARCEL_SURPLUS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class DeepTunnel(BaseDocumentModel):
     description = models.TextField()
-    source_file = models.FileField(upload_to='DEEP_PARCEL_SURPLUS')
+    source_file = models.FileField(upload_to='DEEP_PARCEL_SURPLUS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class Dossier(BaseDocumentModel):
-    file_number = models.CharField(max_length=255)
-    document_number = models.CharField(max_length=3)
-    source_file = models.FileField(upload_to='DOSSIER_FILES')
+    file_number = models.CharField(max_length=255, validators=[validate_positive_int])
+    document_number = models.CharField(max_length=3, validators=[validate_positive_int])
+    source_file = models.FileField(
+        upload_to='DOSSIER_FILES',
+        validators=[FileExtensionValidator(['pdf'])]
+    )
 
 
 class Easement(BaseDocumentModel):
     easement_number = models.CharField(max_length=255, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
-    source_file = models.FileField(upload_to='EASEMENTS')
+    source_file = models.FileField(upload_to='EASEMENTS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class FlatDrawing(BaseDocumentModel):
@@ -226,7 +232,7 @@ class FlatDrawing(BaseDocumentModel):
     )
     hash = models.CharField(max_length=255, null=True, blank=True)
     cad_file = models.FileField('CAD file', null=True, blank=True)
-    source_file = models.FileField(upload_to='FLAT_DRAWINGS')
+    source_file = models.FileField(upload_to='FLAT_DRAWINGS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class IndexCard(BaseDocumentModel):
@@ -234,7 +240,7 @@ class IndexCard(BaseDocumentModel):
     township = models.CharField(max_length=255)
     section = models.CharField(max_length=255, null=True, blank=True)
     corner = models.CharField(max_length=255, null=True, blank=True)
-    source_file = models.FileField(upload_to='INDEX_CARDS')
+    source_file = models.FileField(upload_to='INDEX_CARDS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class License(BaseDocumentModel):
@@ -263,7 +269,7 @@ class License(BaseDocumentModel):
         help_text=ARRAY_FIELD_HELP_TEXT,
         default=list
     )
-    source_file = models.FileField(upload_to='LICENSES')
+    source_file = models.FileField(upload_to='LICENSES', validators=[FileExtensionValidator(['pdf'])])
 
 
 class ProjectFile(BaseDocumentModel):
@@ -274,12 +280,12 @@ class ProjectFile(BaseDocumentModel):
     description = models.TextField(null=True, blank=True)
     cabinet_number = models.CharField(max_length=255, null=True, blank=True)
     drawer_number = models.CharField(max_length=255, null=True, blank=True)
-    source_file = models.FileField(upload_to='PROJECT_FILES')
+    source_file = models.FileField(upload_to='PROJECT_FILES', validators=[FileExtensionValidator(['pdf'])])
 
 
 class RightOfWay(BaseDocumentModel):
     folder_tab = models.CharField(max_length=255)
-    source_file = models.FileField(upload_to='RIGHT_OF_WAY')
+    source_file = models.FileField(upload_to='RIGHT_OF_WAY', validators=[FileExtensionValidator(['pdf'])])
 
     class Meta:
         verbose_name_plural = 'rights of way'
@@ -316,9 +322,9 @@ class Survey(BaseDocumentModel):
         null=True
     )
     hash = models.CharField(max_length=255, null=True, blank=True)
-    source_file = models.FileField(upload_to='SURVEYS')
+    source_file = models.FileField(upload_to='SURVEYS', validators=[FileExtensionValidator(['pdf'])])
 
 
 class Title(BaseDocumentModel):
     control_number = models.CharField(max_length=255)
-    source_file = models.FileField(upload_to='TITLES')
+    source_file = models.FileField(upload_to='TITLES', validators=[FileExtensionValidator(['pdf'])])

--- a/docsearch/models.py
+++ b/docsearch/models.py
@@ -305,12 +305,12 @@ class License(BaseDocumentModel):
 
 
 class ProjectFile(BaseDocumentModel):
-    area = models.PositiveIntegerField(null=True, blank=True)
-    section = models.PositiveIntegerField(null=True, blank=True)
+    area = models.PositiveIntegerField(null=True, blank=True, validators=[validate_int_btwn(1, 33)])
+    section = models.PositiveIntegerField(null=True, blank=True, validators=[validate_int_btwn(1, 36)])
     job_number = models.CharField(max_length=255, null=True, blank=True)
     job_name = models.CharField(max_length=255, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
-    cabinet_number = models.CharField(max_length=255, null=True, blank=True)
+    cabinet_number = models.CharField(max_length=255, null=True, blank=True, validators=[validate_int_btwn(1, 10)])
     drawer_number = models.CharField(max_length=255, null=True, blank=True)
     source_file = models.FileField(upload_to='PROJECT_FILES', validators=[FileExtensionValidator(['pdf'])])
 

--- a/docsearch/models.py
+++ b/docsearch/models.py
@@ -9,7 +9,7 @@ from django.contrib.postgres import forms as pg_forms
 from django.contrib.gis.db import models as gis_models
 from django.core.validators import FileExtensionValidator
 
-from .validators import validate_positive_int
+from .validators import validate_positive_int, validate_range, check_value
 
 
 class InclusiveIntegerRangeFormField(pg_forms.IntegerRangeField):
@@ -162,16 +162,19 @@ class Book(BaseDocumentModel):
         max_length=255,
         null=True,
         blank=True,
+        validators=[validate_range(min=35, max=42)],
         help_text=RANGE_FIELD_HELP_TEXT)
     range = InclusiveIntegerRangeField(
         max_length=255,
         null=True,
         blank=True,
+        validators=[validate_range(min=9, max=15)],
         help_text=RANGE_FIELD_HELP_TEXT)
     section = InclusiveIntegerRangeField(
         max_length=255,
         null=True,
         blank=True,
+        validators=[validate_range(min=1, max=36)],
         help_text=RANGE_FIELD_HELP_TEXT)
     source_file = models.FileField(upload_to='BOOKS', validators=[FileExtensionValidator(['pdf'])])
 
@@ -208,7 +211,7 @@ class Dossier(BaseDocumentModel):
 
 
 class Easement(BaseDocumentModel):
-    easement_number = models.CharField(max_length=255, null=True, blank=True)
+    easement_number = models.CharField(max_length=255, validators=[validate_positive_int], null=True, blank=True)
     description = models.TextField(null=True, blank=True)
     source_file = models.FileField(upload_to='EASEMENTS', validators=[FileExtensionValidator(['pdf'])])
 
@@ -326,5 +329,5 @@ class Survey(BaseDocumentModel):
 
 
 class Title(BaseDocumentModel):
-    control_number = models.CharField(max_length=255)
+    control_number = models.CharField(max_length=255, validators=[validate_positive_int])
     source_file = models.FileField(upload_to='TITLES', validators=[FileExtensionValidator(['pdf'])])

--- a/docsearch/models.py
+++ b/docsearch/models.py
@@ -330,24 +330,27 @@ class RightOfWay(BaseDocumentModel):
 class Survey(BaseDocumentModel):
     township = pg_fields.ArrayField(
         models.PositiveIntegerField(null=True, blank=True),
+        validators=[validate_int_array(35, 42)],
         help_text=ARRAY_FIELD_HELP_TEXT
     )
     section = pg_fields.ArrayField(
         models.PositiveIntegerField(null=True, blank=True),
+        validators=[validate_int_array(1, 36)],
         help_text=ARRAY_FIELD_HELP_TEXT
     )
     range = pg_fields.ArrayField(
         models.PositiveIntegerField(null=True, blank=True),
+        validators=[validate_int_array(9, 15)],
         help_text=ARRAY_FIELD_HELP_TEXT
     )
     map_number = models.CharField(max_length=255, null=True, blank=True)
     location = models.TextField(blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     job_number = models.CharField(max_length=255, blank=True, null=True)
-    number_of_sheets = models.CharField(max_length=255, blank=True, null=True)
-    date = models.CharField(max_length=255, blank=True, null=True)
-    cross_ref_area = models.PositiveIntegerField(blank=True, null=True)
-    cross_ref_section = models.PositiveIntegerField(blank=True, null=True)
+    number_of_sheets = models.CharField(max_length=255, blank=True, null=True, validators=[validate_positive_int])
+    date = models.CharField(max_length=255, blank=True, null=True, validators=[validate_date], help_text=DATE_FIELD_HELP_TEXT)
+    cross_ref_area = models.PositiveIntegerField(blank=True, null=True, validators=[validate_int_btwn(1, 33)])
+    cross_ref_section = models.PositiveIntegerField(blank=True, null=True, validators=[validate_int_btwn(1, 36)])
     cross_ref_map_number = models.CharField(
         max_length=255,
         blank=True,

--- a/docsearch/models.py
+++ b/docsearch/models.py
@@ -275,11 +275,11 @@ class IndexCard(BaseDocumentModel):
 
 class License(BaseDocumentModel):
     TYPE_CHOICES = [
-        ("combined sewer", "Combined Sewer"),
+        ("combined_sewer", "Combined Sewer"),
         ("electric", "Electric"),
         ("gas", "Gas"),
         ("pipeline", "Pipeline"),
-        ("sanitary sewer", "Sanitary Sewer"),
+        ("sanitary_sewer", "Sanitary Sewer"),
         ("storm sewer", "Storm Sewer"),
         ("telecom", "Telecom"),
         ("water main", "Water Main"),

--- a/docsearch/models.py
+++ b/docsearch/models.py
@@ -164,7 +164,6 @@ class Book(BaseDocumentModel):
         max_length=255,
         null=True,
         blank=True,
-        validators=[validate_int_range(min=35, max=42)],
         help_text=RANGE_FIELD_HELP_TEXT)
     range = InclusiveIntegerRangeField(
         max_length=255,
@@ -189,7 +188,6 @@ class ControlMonumentMap(BaseDocumentModel):
 
     township = models.PositiveIntegerField(
         null=True,
-        validators=[validate_int_btwn(35, 42)]
     )
     range = models.PositiveIntegerField(
         null=True,
@@ -321,7 +319,6 @@ class License(BaseDocumentModel):
     agreement_type = models.CharField(max_length=255, null=True, blank=True)
     township = pg_fields.ArrayField(
         models.PositiveIntegerField(null=True),
-        validators=[validate_int_array(35, 42)],
         help_text=ARRAY_FIELD_HELP_TEXT,
         default=list
     )
@@ -366,7 +363,6 @@ class RightOfWay(BaseDocumentModel):
 class Survey(BaseDocumentModel):
     township = pg_fields.ArrayField(
         models.PositiveIntegerField(null=True, blank=True),
-        validators=[validate_int_array(35, 42)],
         help_text=ARRAY_FIELD_HELP_TEXT
     )
     section = pg_fields.ArrayField(

--- a/docsearch/static/css/custom.css
+++ b/docsearch/static/css/custom.css
@@ -151,3 +151,7 @@ footer a.dropdown-item {
   color:red;
   font-size: 1.3em;
 }
+
+.invalid-feedback {
+  display: block;
+}

--- a/docsearch/validators.py
+++ b/docsearch/validators.py
@@ -1,0 +1,8 @@
+from django.core.exceptions import ValidationError
+
+def validate_positive_int(value):
+    if int(value) <= 0:
+        raise ValidationError(
+            ("Please enter a positive number, %(value)s is not valid."),
+            params={"value": value},
+        )

--- a/docsearch/validators.py
+++ b/docsearch/validators.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+import re
 
 def validate_positive_int(value):
     if int(value) <= 0:
@@ -6,8 +7,11 @@ def validate_positive_int(value):
             ("Please enter a positive number, %(value)s is not valid."),
             params={"value": value},
         )
-    
-def validate_range(min, max):
+
+
+def validate_int_range(min, max):
+    # Check that a 2 integer range is between the min and max
+
     def validator(value):
         # Change the NumericRange obj to an indexable array of ints
         value_list = value.__str__().strip('][').split(', ')
@@ -29,7 +33,89 @@ def validate_range(min, max):
     return validator
 
 
+def validate_int_btwn(min, max):
+    # Check that a single integer is between the min and max
+
+    def validator(value):
+        if value < min or value > max:
+            raise ValidationError(
+                ("Please enter a number between %(min)s and %(max)s. The number %(value)s is not valid."),
+                params={
+                    "value": value,
+                    "min": min,
+                    "max": max
+                },
+            )
+    
+    return validator
+
+
+def validate_int_array(min, max):
+    # Check that a list/array of integers is between the min and max
+
+    def validator(value):
+        valid = True
+        invalid_ints = []
+
+        for int in value:
+            if int < min or int > max:
+                valid = False
+                invalid_ints.append(int)
+        
+        if not valid:
+            invalid_ints = [str(i) for i in invalid_ints]
+            raise ValidationError(
+                ("Please enter numbers between %(min)s and %(max)s. The number(s) %(invalid)s is/are not valid."),
+                params={
+                    "invalid": ", ".join(invalid_ints),
+                    "min": min,
+                    "max": max
+                },
+            )
+
+    return validator
+
+
+def validate_date(value):
+    print(value)
+    pattern = re.compile(r"^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$")
+    date_error='Please enter the date as "YYYY-MM-DD", ensuring that the date exists. The date %(value)s is not valid.'
+
+    if not re.fullmatch(pattern, value):
+        raise ValidationError(
+                (date_error),
+                params={"value": value,},
+            )
+    year = int(value[0:4])
+    month = int(value[5:7])
+    day = int(value[8:])
+
+    # Validate days for most months
+    if month in [4,6,9,11] and day > 30:
+        raise ValidationError(
+                (date_error),
+                params={"value": value,},
+            )
+    elif month in [1,3,5,7,8,10,12] and day > 31:
+        raise ValidationError(
+                (date_error),
+                params={"value": value,},
+            )
+
+    # Account for February
+    if year % 4 == 0 and month == 2 and day > 29:
+        raise ValidationError(
+                (date_error),
+                params={"value": value,},
+            )
+    elif year % 4 != 0 and month == 2 and day > 28:
+        raise ValidationError(
+                (date_error),
+                params={"value": value,},
+            )
+
+
 def check_value(value):
-    # For testing purposes only. Delete before finishing
+    # TODO: For testing purposes only. Delete before finishing
     if value:
         print("The value is:", value)

--- a/docsearch/validators.py
+++ b/docsearch/validators.py
@@ -37,7 +37,7 @@ def validate_int_btwn(min, max):
     # Check that a single integer is between the min and max
 
     def validator(value):
-        if value < min or value > max:
+        if int(value) < min or int(value) > max:
             raise ValidationError(
                 ("Please enter a number between %(min)s and %(max)s. The number %(value)s is not valid."),
                 params={
@@ -77,7 +77,6 @@ def validate_int_array(min, max):
 
 
 def validate_date(value):
-    print(value)
     pattern = re.compile(r"^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$")
     date_error='Please enter the date as "YYYY-MM-DD", ensuring that the date exists. The date %(value)s is not valid.'
 

--- a/docsearch/validators.py
+++ b/docsearch/validators.py
@@ -116,7 +116,11 @@ def validate_date(value):
             )
 
 
-def check_value(value):
-    # TODO: For testing purposes only. Delete before finishing
-    if value:
-        print("The value is:", value)
+def validate_license_num(value):
+    # Check that the license number is a hyphenated string starting with "O" and ending with an integer
+
+    if not value[:2] == "O-" or not value[2:].isnumeric():
+        raise ValidationError(
+            ("Please enter a hyphenated string starting with 'O' and ending with an integer, '%(value)s' is not valid."),
+            params={"value": value},
+        )

--- a/docsearch/validators.py
+++ b/docsearch/validators.py
@@ -2,9 +2,11 @@ from django.core.exceptions import ValidationError
 import re
 
 def validate_positive_int(value):
-    if int(value) <= 0:
+    # Check that the value is a positive integer
+
+    if not value.isnumeric() or int(value) <= 0:
         raise ValidationError(
-            ("Please enter a positive number, %(value)s is not valid."),
+            ("Please enter a positive number, '%(value)s' is not valid."),
             params={"value": value},
         )
 

--- a/docsearch/validators.py
+++ b/docsearch/validators.py
@@ -6,3 +6,30 @@ def validate_positive_int(value):
             ("Please enter a positive number, %(value)s is not valid."),
             params={"value": value},
         )
+    
+def validate_range(min, max):
+    def validator(value):
+        # Change the NumericRange obj to an indexable array of ints
+        value_list = value.__str__().strip('][').split(', ')
+        if value_list[1] == 'None':
+            raise ValidationError("Please enter values into both fields")
+        value_list = [int(num) for num in value_list]
+        
+        if value_list[0] < min or value_list[1] > max:
+            raise ValidationError(
+                ("Please enter a valid range between %(min)s and %(max)s. Range %(value0)s and %(value1)s is not valid."),
+                params={
+                    "value0": value_list[0],
+                    "value1": value_list[1],
+                    "min": min,
+                    "max": max
+                },
+            )
+
+    return validator
+
+
+def check_value(value):
+    # For testing purposes only. Delete before finishing
+    if value:
+        print("The value is:", value)


### PR DESCRIPTION
## Overview

This begins to add validation for create and edit views. This is done through model validators for all fields except `geometry`, where we're instead catching exceptions raised in both `LicenseForm` in forms.py and a custom widget in licenses.py

Connects #41 

### Notes

This does not include the items in #41 that needed updated rules, like `township` or `job_number` fields. Any other fields not mentioned in [this comment](https://github.com/fpdcc/document-search/issues/41#issuecomment-1563491203) should be good to go.

The fields that do have new validation should still accept existing values with little to no modification.

## Testing Instructions

* Create/edit a few types of documents with incorrect and correct inputs
* Confirm that:
  * Proper errors display and the document is not saved when incorrect
  * The document is saved when inputs are correct
