### PR TITLE
Search for exact facets w/o cleaning if field specifies

### DIFF
--- a/docsearch/forms.py
+++ b/docsearch/forms.py
@@ -4,6 +4,7 @@ from django.forms import ModelForm, ValidationError
 from django.contrib.gis.forms.fields import GeometryCollectionField
 from haystack.query import SQ
 from haystack.forms import SearchForm
+from haystack.inputs import Exact
 
 from docsearch.models import License
 from docsearch.query import FuzzyAutoQuery
@@ -35,7 +36,10 @@ class BaseSearchForm(SearchForm):
 
             field, value = facet.split(":", 1)
 
-            facet_filter |= SQ(**{field: sqs.query.clean(value)})
+            if "_exact" in field:
+                facet_filter |= SQ(**{field: Exact(value)})
+            else:
+                facet_filter |= SQ(**{field: sqs.query.clean(value)})
 
         sqs = sqs.filter(facet_filter)
 


### PR DESCRIPTION
## Overview

When searching with a facet, cleaning that facet's value was causing special characters to get escaped, which changed the value before the search was conducted. This caused existing facets like `00-04` to be used in the search as `00\\-04` and would return 0 results.

This branch adjusts the search to not sanitize facet values if the facet field has the string `_exact`. This way, the value's special characters don't get escaped and can be used to filter as is.

- Closes #112

## Testing Instructions

* Navigate to the Flat Drawing search page
* Enter a search term like "Ryan"
* Click different facets to confirm that
  * Facets with characters like `-` or `/` return the number of results they say they would
  * Facets without those characters still work as normal
