### PR TITLE
Improve search scores for direct matches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
             mkdir -p data && touch data/requirements.txt
             cp .env.example .env
-            docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
+            docker compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
   deploy:
     if:
       contains('

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ cp docsearch/local_settings.example.py docsearch/local_settings.dev.py
 Next, build containers:
 
 ```
-docker-compose build
+docker compose build
 ```
 
 Run the app:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 The app will be available at http://localhost:8000. The database will be exposed
@@ -42,7 +42,7 @@ on port 32001.
 Create a superuser to view the application:
 
 ```
-docker-compose run --rm app ./manage.py createsuperuser
+docker compose run --rm app ./manage.py createsuperuser
 ```
 
 ### Loading initial data
@@ -67,19 +67,19 @@ cp -R ./document-search-data/ ./document-search/data/
 Then, load initial data using GNU Make:
 
 ```
-docker-compose -f docker-compose.yml -f data/docker-compose.yml run --rm app make all
+docker compose -f docker-compose.yml -f data/docker-compose.yml run --rm app make all
 ```
 
 To create the search index, start by bringing up Solr in one shell:
 
 ```
-docker-compose up solr
+docker compose up solr
 ```
 
 Then, in another shell, run the `rebuild_index` command:
 
 ```
-docker-compose run --rm app ./manage.py rebuild_index
+docker compose run --rm app ./manage.py rebuild_index
 ```
 
 ### Running tests
@@ -87,7 +87,7 @@ docker-compose run --rm app ./manage.py rebuild_index
 Run tests with Docker Compose:
 
 ```
-docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
+docker compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```
 
 ## Deployment

--- a/docsearch/views/base.py
+++ b/docsearch/views/base.py
@@ -148,18 +148,23 @@ class BaseSearchView(LoginRequiredMixin, DocumentPermissionRequiredMixin, Facete
         sqs = super().get_queryset().models(self.model)
 
         q = self.request.GET.get('q')
-        exact_match_re = re.compile(r'"(?P<phrase>.*?)"')
         if q:
             """
             Boost results that contain direct matches of each term in the query,
             regardless of whether any terms are enclosed in double quotes.
-            For terms in double quotes, ensure that they get boosted as is,
-            whitespace and all.
+            Terms in double quotes are exact match terms, so give them a bit of
+            an extra boost, and boost them as is - whitespace and all.
             """
+            exact_match_re = re.compile(r'"(?P<phrase>.*?)"')
             tokens = exact_match_re.split(q)
+            exacts = exact_match_re.findall(q)
+
             for t in tokens:
                 if t and not t.strip().startswith("-"):
-                    sqs = sqs.boost(t, .5)
+                    if t in exacts:
+                        sqs = sqs.boost(t, 1)
+                    else:
+                        sqs = sqs.boost(t, .5)
 
         for facet_field in self.facet_fields:
             # Sort facet options alphabetically, not by hit count

--- a/scripts/after_install.sh
+++ b/scripts/after_install.sh
@@ -78,7 +78,7 @@ $VENV_DIR/bin/python $PROJECT_DIR/scripts/render_configs.py $DEPLOYMENT_ID $DEPL
 echo "DEPLOYMENT_ID='$DEPLOYMENT_ID'" > $PROJECT_DIR/docsearch/deployment.py
 
 # Make sure Solr is running
-(docker ps | grep document-search-solr) || (cd $PROJECT_DIR && docker-compose up -d solr)
+(docker ps | grep document-search-solr) || (cd $PROJECT_DIR && docker compose up -d solr)
 
 
 # Add the virtualenv directory name to python command in the script


### PR DESCRIPTION
## Overview

This branch boosts results which have a direct match to the search query. For some reason, haystack/solr has been inconsistent about placing direct matches for license numbers at the top of the search results.

- Closes #121 
- Closes #122 
 
### Demo
**Note: for the purposes of this demo, I've added the search scores of each result to the license number cell. This change has not been pushed here.**

Searching for "556" before boosting (result found on second page):
![image](https://github.com/user-attachments/assets/d75a0a89-6f6a-4a96-882a-eed5c62769f0)

---

After boosting (first result):
![image](https://github.com/user-attachments/assets/deb67173-4f2f-4f29-9acb-adc6960e8b45)

### Notes

I don't have any building ids in my flat drawings so I tested those rankings using map numbers instead.

## Testing Instructions

* Pull down this branch and search for licenses or flat drawings
  * May need to create a super user
* Confirm that results which are more relevant are now higher in search results
