### PR TITLE
Fix diameter validator when creating licenses

### DIFF
--- a/docsearch/validators.py
+++ b/docsearch/validators.py
@@ -4,8 +4,7 @@ import re
 
 def validate_positive_int(value):
     # Check that the value is a positive integer
-
-    if not value.isnumeric() or int(value) <= 0:
+    if int(value) <= 0:
         raise ValidationError(
             ("Please enter a positive number, '%(value)s' is not valid."),
             params={"value": value},


### PR DESCRIPTION
## Overview

The `diameter` field in the license creation form has a validator that expects a string but receives a integer, throwing an error while saving. This PR fixes this validator.

[See related Sentry error.](https://datamade.sentry.io/issues/6798831922/?project=4509798941589504&query=is%3Aunresolved&referrer=issue-stream)

Connects #128 

## Testing Instructions

* Before pulling down this branch, replicate the error by navigating to the create license page, inputting a diameter value and attempting to save
* Verify that this branch fixes the error
