### PR TITLE
Fix search facets not showing correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ docker compose run --rm app ./manage.py createsuperuser
 
 ### Loading initial data
 
-Initial data is available in a separate repo, `document-search-data`, that is
+Initial data is available in separate repos, called `document-search-data`, that are
 kept private in order to respect the privacy of entities mentioned in the
-metadata. The repo is hosted on AWS CodeCommit in the Forest Preserves AWS account.
+metadata. One repo is hosted on a private DataMade github repo, and another on AWS CodeCommit in the Forest Preserves AWS account.
 
-To get the data in that repo, the easiest option is to ask a fellow dev to send you a zipped version of the `/data` directory from the root of their local environment and unzip it in a similar directory in your environment. If this is not possible, then jump to these [instructions for cloning the private repo](#cloning-document-search-data) and return here when done.
+To get that data, the easiest options are to:
+- Clone it from [DataMade's private repo of the data](https://github.com/datamade/document-search-data), and copy that into a directory called `/data` in the root of your local environment.
+- Ask a fellow dev to send you a zipped version of the `/data` directory from the root of their local environment and unzip it in a similar directory in your environment. 
+
+If neither option is possible, you can also follow these [instructions for cloning CCFP's version of the same repo on AWS](#cloning-document-search-data) and return here when done.
 
 Once you have initial `/data/` locally, load it using GNU Make:
 
@@ -73,7 +77,7 @@ docker compose run --rm app ./manage.py rebuild_index
 
 Voila, you now have Licenses, and Titles, and Books, oh my!
 
-#### Cloning `document-search-data`
+#### Cloning `document-search-data` from AWS
 To gain access to cloning `document-search-data`, you'll need to add yourself to the SSH keys for CodeCommit.
 
 First, log in to AWS using the credentials in Bitwarden titled "CCFP Forest Preserve of Cook County AWS creds". Make sure you're on the "us-east-1" regional version of the site after logging in.
@@ -106,5 +110,12 @@ This repo is configured to deploy in the following ways:
 | ----------- | ------------------------- |
 | staging     | commit to `master` branch |
 | production  | tagged commit or release  |
+
+Push to production using the following commands:
+```bash
+git tag <new-tag-name>  # create new tag
+git tag  # list all tags to confirm creation
+git push origin —-tags  # push all local tags, including the new one
+```
 
 In both cases, Travis CI will run tests before triggering a new deployment with AWS CodeDeploy.

--- a/README.md
+++ b/README.md
@@ -50,27 +50,16 @@ docker compose run --rm app ./manage.py createsuperuser
 Initial data is available in a separate repo, `document-search-data`, that is
 kept private in order to respect the privacy of entities mentioned in the
 metadata. The repo is hosted on AWS CodeCommit in the Forest Preserves AWS account.
-Request access to the repo, or open an issue here to request assistance
-preparing your own metadata for an initial import.
 
-For guidance on configuring your local environment to work with AWS CodeCommit,
-see the [official AWS
-docs](https://docs.aws.amazon.com/codecommit/latest/userguide/getting-started-cc.html).
+To get the data in that repo, the easiest option is to ask a fellow dev to send you a zipped version of the `/data` directory from the root of their local environment and unzip it in a similar directory in your environment. If this is not possible, then jump to these [instructions for cloning the private repo](#cloning-document-search-data) and return here when done.
 
-Once you have access to `document-search-data`, clone it and copy it to a
-subdirectory of this repo called `data/`:
-
-```
-cp -R ./document-search-data/ ./document-search/data/
-```
-
-Then, load initial data using GNU Make:
+Once you have initial `/data/` locally, load it using GNU Make:
 
 ```
 docker compose -f docker-compose.yml -f data/docker-compose.yml run --rm app make all
 ```
 
-To create the search index, start by bringing up Solr in one shell:
+To get documents to show up on the frontend, you'll need to create the search index. Start by bringing up Solr in one shell if it hasn't been started by the container itself:
 
 ```
 docker compose up solr
@@ -81,6 +70,25 @@ Then, in another shell, run the `rebuild_index` command:
 ```
 docker compose run --rm app ./manage.py rebuild_index
 ```
+
+Voila, you now have Licenses, and Titles, and Books, oh my!
+
+#### Cloning `document-search-data`
+To gain access to cloning `document-search-data`, you'll need to add yourself to the SSH keys for CodeCommit.
+
+First, log in to AWS using the credentials in Bitwarden titled "CCFP Forest Preserve of Cook County AWS creds". Make sure you're on the "us-east-1" regional version of the site after logging in.
+
+Find the detail page for the "datamade" IAM user, click "Security credentials", and scroll down to "SSH public keys for AWS CodeCommit". Note that a max of 5 users can be added to the "datamade" user at once. You may choose to perform this action on a new user.
+
+From here, follow [step 3 in the AWS docs to add your ssh key](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html?icmpid=docs_acc_console_connect#setting-up-ssh-unixes-keys), making sure to create an `rsa` formatted key. Then follow [step 4 in those same docs to clone the repo](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html?icmpid=docs_acc_console_connect#setting-up-ssh-unixes-connect-console).
+
+Last, copy the contents of that repo to a subdirectory of this repo called `/data/`:
+
+```
+cp -R ./document-search-data/ ./document-search/data/
+```
+
+For additional guidance on configuring your local environment to work with AWS CodeCommit. see the [official AWS docs](https://docs.aws.amazon.com/codecommit/latest/userguide/getting-started-cc.html).
 
 ### Running tests
 

--- a/docsearch/templates/docsearch/base_search.html
+++ b/docsearch/templates/docsearch/base_search.html
@@ -130,31 +130,33 @@
                       </div>
                     {% endif %}
                     <div id="{{ facet_field }}-list-widget" {% if facet_field in view.geo_facet_fields %}style="display:none"{% endif %}>
-                      <div class="card-body pb-0">
-                        <ul class="pl-0" style="list-style-type:none">
-                          {% for value, count in facets.fields|get_key:facet_field %}
-                            {% if count > 0 %}
-                              {% with facet_field_exact|add:":"|add:value as facet_query %}
-                                <li class="border-bottom mb-1">
-                                  <div class="d-inline-block" style="width:80%">
-                                    {% if facet_query in selected_facets %}
-                                      <a href="?{% remove_facet_param parameters facet_field_exact value %}" title="{{ value }}">
-                                        <strong>{{ value }}</strong>&nbsp;<i class="fa fa-fw fa-times"></i>
+                      <div class="card-body pb-0 pr-0">
+                        <div class="pr-3" style="max-height: 400px; overflow-y: auto;">
+                          <ul class="pl-0" style="list-style-type:none">
+                            {% for value, count in facets.fields|get_key:facet_field %}
+                              {% if count > 0 %}
+                                {% with facet_field_exact|add:":"|add:value as facet_query %}
+                                  <li class="border-bottom mb-1">
+                                    <div class="d-inline-block" style="width:80%">
+                                      {% if facet_query in selected_facets %}
+                                        <a href="?{% remove_facet_param parameters facet_field_exact value %}" title="{{ value }}">
+                                          <strong>{{ value }}</strong>&nbsp;<i class="fa fa-fw fa-times"></i>
+                                        </a>
+                                      {% else %}
+                                      <a href="?{% set_facet_param parameters facet_field_exact value %}" title="{{ value }}">
+                                        {{ value }}
                                       </a>
-                                    {% else %}
-                                    <a href="?{% set_facet_param parameters facet_field_exact value %}" title="{{ value }}">
-                                      {{ value }}
-                                    </a>
-                                    {% endif %}
-                                  </div>
-                                  <div class="d-inline-block align-top" style="width:15%">
-                                    <span class="badge badge-secondary rounded-pill float-right">{{ count }}</span>
-                                  </div>
-                                </li>
-                              {% endwith %}
-                            {% endif %}
-                          {% endfor %}
-                        </ul>
+                                      {% endif %}
+                                    </div>
+                                    <div class="d-inline-block align-top" style="width:15%">
+                                      <span class="badge badge-secondary rounded-pill float-right">{{ count }}</span>
+                                    </div>
+                                  </li>
+                                {% endwith %}
+                              {% endif %}
+                            {% endfor %}
+                          </ul>
+                        </div>
                       </div>
                       {% if facet_field in view.geo_facet_fields %}
                         <button

--- a/docsearch/views/base.py
+++ b/docsearch/views/base.py
@@ -168,7 +168,7 @@ class BaseSearchView(LoginRequiredMixin, DocumentPermissionRequiredMixin, Facete
 
         for facet_field in self.facet_fields:
             # Sort facet options alphabetically, not by hit count
-            sqs = sqs.facet(facet_field, sort='index', limit=1000)
+            sqs = sqs.facet(facet_field, sort='index', mincount=1, limit=-1)
         sort = self._get_sort()
         if sort:
             sqs = sqs.order_by(sort)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ Django==2.2.13
 psycopg2==2.8.4
 django-storages==1.8
 django-crispy-forms==1.8.1
-boto3==1.10.38
+boto3==1.21.0
 django-haystack==2.8.1
 pysolr==3.8.1
 gunicorn==20.0.4
 django-leaflet==0.26.0
 django-datatables-view==1.19.1
-sentry-sdk[django]
+sentry-sdk[django]==2.34.1


### PR DESCRIPTION
## Overview

This pr ensures that all relevant facets appear when performing a search. We're now removing the limit on facet results, while excluding facets that don't have any related search results.

- Connects #131

### Demo
<img width="1053" height="912" alt="image" src="https://github.com/user-attachments/assets/f4ba6031-482f-4b44-903b-ca0e392ec748" />

### Notes
We were originally limiting results to 1000 facets on the backend, and that would include irrelevant facets that had no hits for the current search. That meant a license number above about 405 that isn't listed within the first 1000 facets would be excluded from the facets we show on the frontend.

Additionally, since we were already only showing relevant facets on the frontend, this pr makes the backend match that pattern of exclusion.

## Testing Instructions

* Pull down this branch, bring up the container, and log in
* Head to the licenses search and try searching a few different license numbers
  * Confirm that searching for a license number above 405 returns that license number in the "license number" dropdown
  * Confirm that searching for other license numbers and other fields still works as expected
