### PR TITLE
Improve onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,27 +50,16 @@ docker compose run --rm app ./manage.py createsuperuser
 Initial data is available in a separate repo, `document-search-data`, that is
 kept private in order to respect the privacy of entities mentioned in the
 metadata. The repo is hosted on AWS CodeCommit in the Forest Preserves AWS account.
-Request access to the repo, or open an issue here to request assistance
-preparing your own metadata for an initial import.
 
-For guidance on configuring your local environment to work with AWS CodeCommit,
-see the [official AWS
-docs](https://docs.aws.amazon.com/codecommit/latest/userguide/getting-started-cc.html).
+To get the data in that repo, the easiest option is to ask a fellow dev to send you a zipped version of the `/data` directory from the root of their local environment and unzip it in a similar directory in your environment. If this is not possible, then jump to these [instructions for cloning the private repo](#cloning-document-search-data) and return here when done.
 
-Once you have access to `document-search-data`, clone it and copy it to a
-subdirectory of this repo called `data/`:
-
-```
-cp -R ./document-search-data/ ./document-search/data/
-```
-
-Then, load initial data using GNU Make:
+Once you have initial `/data/` locally, load it using GNU Make:
 
 ```
 docker compose -f docker-compose.yml -f data/docker-compose.yml run --rm app make all
 ```
 
-To create the search index, start by bringing up Solr in one shell:
+To get documents to show up on the frontend, you'll need to create the search index. Start by bringing up Solr in one shell if it hasn't been started by the container itself:
 
 ```
 docker compose up solr
@@ -81,6 +70,25 @@ Then, in another shell, run the `rebuild_index` command:
 ```
 docker compose run --rm app ./manage.py rebuild_index
 ```
+
+Voila, you now have Licenses, and Titles, and Books, oh my!
+
+#### Cloning `document-search-data`
+To gain access to cloning `document-search-data`, you'll need to add yourself to the SSH keys for CodeCommit.
+
+First, log in to AWS using the credentials in Bitwarden titled "CCFP Forest Preserve of Cook County AWS creds". Make sure you're on the "us-east-1" regional version of the site after logging in.
+
+Find the detail page for the "datamade" IAM user, click "Security credentials", and scroll down to "SSH public keys for AWS CodeCommit". Note that a max of 5 users can be added to the "datamade" user at once. You may choose to perform this action on a new user.
+
+From here, follow [step 3 in the AWS docs to add your ssh key](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html?icmpid=docs_acc_console_connect#setting-up-ssh-unixes-keys), making sure to create an `rsa` formatted key. Then follow [step 4 in those same docs to clone the repo](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-ssh-unixes.html?icmpid=docs_acc_console_connect#setting-up-ssh-unixes-connect-console).
+
+Last, copy the contents of that repo to a subdirectory of this repo called `/data/`:
+
+```
+cp -R ./document-search-data/ ./document-search/data/
+```
+
+For additional guidance on configuring your local environment to work with AWS CodeCommit. see the [official AWS docs](https://docs.aws.amazon.com/codecommit/latest/userguide/getting-started-cc.html).
 
 ### Running tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ Django==2.2.13
 psycopg2==2.8.4
 django-storages==1.8
 django-crispy-forms==1.8.1
-boto3==1.10.38
+boto3==1.21.0
 django-haystack==2.8.1
 pysolr==3.8.1
 gunicorn==20.0.4
 django-leaflet==0.26.0
 django-datatables-view==1.19.1
-sentry-sdk[django]
+sentry-sdk[django]==2.34.1


### PR DESCRIPTION
## Overview

This pr primarily improves upon our documentation for getting access to the dev data. This also pins a couple of the packages to specific versions to prevent the app from hanging forever on the build step.

- Closes #126 

### Notes
I tried out the steps myself and was able to clone the private repo!

I have this comparing to `fix/search-criteria` for clarity's sake since this is branched off of that. But I can move this back over to `master` if that one comes in first.

## Testing Instructions

* Build the app without a cache and confirm that the process only takes a few minutes.
* Read the steps for cloning the data repo and confirm that they are clear
  * (Optional)Try the steps for cloning the data repo to confirm that they work